### PR TITLE
Version 2.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset                  = utf-8
+end_of_line              = lf
+insert_final_newline     = true
+trim_trailing_whitespace = true
+indent_style             = space
+indent_size              = 4
+
+[.editorconfig]
+ij_editorconfig_align_group_field_declarations     = true
+ij_editorconfig_space_after_comma                  = true
+ij_editorconfig_spaces_around_assignment_operators = true
+
+[*.php]
+ij_php_concat_spaces                 = true
+ij_php_space_after_unary_not         = false
+ij_php_space_before_unary_not        = false
+ij_php_spaces_around_shift_operators = true
+ij_php_variable_naming_style         = camel_case
+ij_php_getters_setters_naming_style  = camel_case

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,8 @@ class CompanyFixtures extends Fixture
 }
 ```
 
-By adding `Marty\McFly\Fixture`, you must adhere to the `Marty\McFly\Interface\CreateInterface` interface and add a `create()` function.
+By adding `Marty\McFly\Fixture`, you must adhere to the `Marty\McFly\Interface\CreateInterface` interface and add a `generate()` function.
+> ⚠️ The `create()` function was renamed to `generate()` between v1 and v2 to avoid breaking changes. The `create()` function is still compatible but it is recommended to migrate to `generate()` to benefit from the new features.
 
 ```php
 <?php
@@ -53,20 +54,25 @@ class CompanyFixtures extends Fixture
 {
     public function load(ObjectManager $manager): void
     {
-        // $this->create();
+        // $this->generate();
 
         $manager->flush();
     }
 
+    public function generate(?array $properties = null, array|string|null $references = null): object
+    {
+        // TODO: Implement generate() method.
+        throw new \RuntimeException("The generate() method is not implemented.");
+    }
+
     public function create(array|string $references = null): object
     {
-        // TODO: Implement create() method.
-        throw new \RuntimeException("The create() method is not implemented.");
+
     }
 }
 ```
 
-Configure your template (create() is a factory)
+Configure your template (`generate()` is a factory, work with Reflection without setters or _construct)
 
 ```php
 <?php
@@ -83,20 +89,65 @@ class CompanyFixtures extends Fixture
     public function load(ObjectManager $manager): void
     {
         // Create a random Company, persist it (for database), and automatically add a reference to use it in other fixtures.
-        $this->create();
-        
-        // Create a random Company to "Paris"
+        $this->generate();
+
+        // Create 10 randoms Companies to "Paris" (Since 2.0)
+        $this->generateMany(10, [
+            'city' => 'Paris',
+            'postalCode' => '75000'
+        ]);
+
+        // Finally, flush to the database
+        $manager->flush();
+    }
+
+    public function generate(?array $properties = null, array|string|null $references = null): object
+    {
+        return $this->createAndSave(Company::class, $properties,
+            [
+                'name'       => self::$faker->company(),
+                'address'    => self::$faker->address(),
+                'city'       => self::$faker->city(),
+                'postalCode' => self::$faker->postcode(),
+            ],
+            $references
+        );
+    }
+
+}
+```
+
+Configure your template : The alternative style (using setter if you have) :
+
+```php
+<?php
+// src/DataFixtures/CompanyFixtures.php
+
+namespace App\DataFixtures;
+
+use App\Entity\Company;
+use Doctrine\Persistence\ObjectManager;
+use Marty\McFly\Fixture;
+
+class CompanyFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        // Create a random Company, persist it (for database), and automatically add a reference to use it in other fixtures.
+        $this->generate();
+
+        // Alternative : Create 10 randoms Companies to "Paris" with setter
         for ($i=0 ; $i<10 ; $i++) {
-            $this->create()
+            $this->generate()
                 ->setCity('Paris')
-                ->setPostalCode('75000');    
+                ->setPostalCode('75000');
         }
 
         // Finally, flush to the database
         $manager->flush();
     }
 
-    public function create(array|string $references = null): object
+    public function generate(?array $properties = null, array|string|null $references = null): object
     {
         $company = (new Company())
             ->setName(self::getFaker()->company())
@@ -126,18 +177,18 @@ class CompanyFixtures extends Fixture
     public function load(ObjectManager $manager): void
     {
         // Create a random Company
-        $this->create();
+        $this->generate();
 
         // Finally, flush to the database
         $manager->flush();
     }
 
-    // ... create() definition
+    // ... generate() definition
 }
 
 ```
 
-Creating an entity by setting only the necessary properties.
+Creating an entity by setting only the necessary properties (recommandation style).
 
 ```php
 <?php
@@ -149,15 +200,41 @@ class CompanyFixtures extends Fixture
     public function load(ObjectManager $manager): void
     {
         // Create a random Company to "Paris"
-        $this->create()
-            ->setCity('Paris')
-            ->setPostalCode('75000');
-        
+        $this->generate([
+            'city'       => 'Paris',
+            'postalCode' => '75000',
+        ]);
+
         // Finally, flush to the database
         $manager->flush();
     }
 
-    // ... create() definition
+    // ... generate() definition
+}
+```
+
+Creating an entity by setting only the necessary properties (alternative style).
+> ⚠️ With this syntax, the entity is create and change after.
+
+```php
+<?php
+
+// ...
+
+class CompanyFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        // Create a random Company to "Paris"
+        $this->generate()
+            ->setCity('Paris')
+            ->setPostalCode('75000');
+
+        // Finally, flush to the database
+        $manager->flush();
+    }
+
+    // ... generate() definition
 }
 ```
 
@@ -172,10 +249,37 @@ class CompanyFixtures extends Fixture
 {
     public function load(ObjectManager $manager): void
     {
-     
+
+        // Create 10 random Company to "Paris"
+        $this->generateMany(10, [
+            'city'       => 'Paris',
+            'postalCode' => '75000',
+        ]);
+
+        // Finally, flush to the database
+        $manager->flush();
+    }
+
+    // ... generate() definition
+}
+
+```
+
+Create multiple entities while customizing certain properties (alternative.
+
+```php
+<?php
+
+// ...
+
+class CompanyFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+
         // Create 10 random Company to "Paris"
         for ($i=0 ; $i<10 ; $i++) {
-            $this->create()
+            $this->generate()
                 ->setCity('Hill Valley')
             ;
         }
@@ -184,7 +288,7 @@ class CompanyFixtures extends Fixture
         $manager->flush();
     }
 
-    // ... create() definition
+    // ... generate() definition
 }
 
 ```
@@ -211,11 +315,11 @@ class UserFixture extends Fixture implements DependentFixtureInterface
         // Use this function to loop through all companies and create users for them.
         /** @var array<Company> $companies */
         $companies = $this->getReferencesByClass(Company::class);
-        
+
         // Need a random company? Use this method.
         /** @var Company $company */
         $company = $this->getRandomReferenceByClass(Company::class);
-    
+
     }
 
     public function create(string|array $references = null): User
@@ -223,7 +327,7 @@ class UserFixture extends Fixture implements DependentFixtureInterface
         // You can also use it in the template to add a default random company.
         /** @var Company $company */
         $company = $this->getRandomReferenceByClass(Company::class);
-        
+
         // ..
     }
 
@@ -247,27 +351,27 @@ class InvoiceFixture extends Fixture implements DependentFixtureInterface
 
     // --
 
-    public function create(string|array $references = null): UnavailablePeriod
+    public function generate(?array $properties = null, array|string|null $references = null): Invoice
     {
-        
-        $invoice = (new Invoice())
-            ->setCreatedAt(new DateTimeImmutable())
-            ->setNumber(InvoiceFixture::count()) // the current number, auto-incrementation and save()
-            ->setUser($this->getRandomReferenceByClass(User::class)) // a random User
-            ->setStatus(self::randomValue(Status::cases())) // randomly a value of Status Enum
-            ->setConfirmed(self::randomValue([True, False])) // randomly True or False
-            ->setComment(self::randomValue([null, self::getFaker()->sentence()])) // Add random sentence or randomly NULL
-        ;
-            
+        $invoice = $this->createAndSave(Invoice::class, $properties,
+            [
+                'createdAt' => new DateTimeImmutable(),
+                'number'    => InvoiceFixture::count(),                                 // the current number, auto-incrementation on save()
+                'user'      => $this->getRandomReferenceByClass(User::class),           // a random User
+                'status'    => self::randomValue(Status::cases()),                      // randomly a value of Status Enum,
+                'confirmed' => self::randomValue([True, False]),                        // randomly True or False
+                'comment'   => self::randomValue([null, self::getFaker()->sentence()]), // Add random sentence or randomly NULL
+                'product'
+            ],
+            $references
+        );
+
         // Add RandomProduct
         for ($i=0 ; $i<10 ; $i++) {
             /** @var Product $product */
             $randomProduct = $this->getRandomReferenceByClass(Product::class);
             $invoice->addProduct($randomProduct);
         }
-
-        // Persist et référence l'entité
-        $this->save($invoice, $references);
 
         return $invoice;
     }

--- a/src/Fixture.php
+++ b/src/Fixture.php
@@ -73,6 +73,23 @@ abstract class Fixture extends DoctrineFixture implements CreateInterface
     }
 
     /**
+     * Create an entity from array (by reflection) with default value, save it and reference it automatically for retrieve
+     */
+    public function createAndSave(
+        string $className,
+        array $properties,
+        array $default = null,
+        array|string $references = null
+    ) {
+
+        $entity = $this->createFromProperties($className, $properties, $default);
+
+        $this->save($entity);
+
+        return $entity;
+    }
+
+    /**
      * @return array<object>
      */
     public function getReferencesByClass(string $class): array

--- a/src/Fixture.php
+++ b/src/Fixture.php
@@ -134,6 +134,17 @@ abstract class Fixture extends DoctrineFixture implements CreateInterface
     }
 
     /**
+     * Generate X entities in one line
+     */
+    public function generateMany(int $number, ?array $properties = null) : array {
+        $list = [];
+        for ($i = 0; $i < $number; $i++) {
+            $list[] = $this->generate($properties);
+        }
+        return $list;
+    }
+
+    /**
      * Create an instance of the entity with Reflection for setting all properties without setter or constructor
      */
     public function createFromProperties(string $className, array $properties, array $default = null)

--- a/src/Fixture.php
+++ b/src/Fixture.php
@@ -139,7 +139,7 @@ abstract class Fixture extends DoctrineFixture implements CreateInterface
     {
 
         // Fusionne avec les valeurs par défaut
-        $properties = array_merge($default, $properties);
+        $properties = array_merge($default ?? [], $properties ?? []);
 
         // Créez une instance de la classe ReflectionClass
         $reflectionClass = new ReflectionClass($className);

--- a/src/Fixture.php
+++ b/src/Fixture.php
@@ -121,14 +121,14 @@ abstract class Fixture extends DoctrineFixture implements CreateInterface
      */
     public function createAndSave(
         string $className,
-        array $properties,
-        array $default = null,
+        ?array $properties = null,
+        ?array $default = null,
         array|string $references = null
     ): object {
 
         $entity = $this->createFromProperties($className, $properties, $default);
 
-        $this->save($entity);
+        $this->save($entity, $references);
 
         return $entity;
     }

--- a/src/Fixture.php
+++ b/src/Fixture.php
@@ -3,12 +3,12 @@
 namespace Marty\McFly;
 
 use Doctrine\Bundle\FixturesBundle\Fixture as DoctrineFixture;
+use Exception;
 use Faker\Factory;
 use Faker\Generator;
 use Marty\McFly\Interface\CreateInterface;
 use ReflectionClass;
 use ReflectionProperty;
-use RuntimeException;
 
 abstract class Fixture extends DoctrineFixture implements CreateInterface
 {
@@ -66,7 +66,7 @@ abstract class Fixture extends DoctrineFixture implements CreateInterface
         $referenceByClass = $this->getReferencesByClass($class);
         $object           = self::randomValue($referenceByClass);
         if ($object === null) {
-            throw new RuntimeException("No reference by $class");
+            throw new \RuntimeException("No reference by $class");
         }
 
         return $object;

--- a/src/Fixture.php
+++ b/src/Fixture.php
@@ -133,17 +133,6 @@ abstract class Fixture extends DoctrineFixture implements CreateInterface
     }
 
     /**
-     * Generate X entities in one line
-     */
-    public function generateMany(int $number, ?array $properties = null) : array {
-        $list = [];
-        for ($i = 0; $i < $number; $i++) {
-            $list[] = $this->generate($properties);
-        }
-        return $list;
-    }
-
-    /**
      * Create an instance of the entity with Reflection for setting all properties without setter or constructor
      */
     public function createFromProperties(string $className, array $properties, array $default = null)
@@ -205,6 +194,19 @@ abstract class Fixture extends DoctrineFixture implements CreateInterface
     {
         $reference = $this->uniqueRef($name, $object::class);
         parent::setReference($reference, $object);
+    }
+
+    /**
+     * Generate X entities in one line
+     */
+    public function generateMany(int $number, ?array $properties = null): array
+    {
+        $list = [];
+        for ($i = 0; $i < $number; $i++) {
+            $list[] = $this->generate($properties);
+        }
+
+        return $list;
     }
 
 }

--- a/src/Fixture.php
+++ b/src/Fixture.php
@@ -6,6 +6,9 @@ use Doctrine\Bundle\FixturesBundle\Fixture as DoctrineFixture;
 use Faker\Factory;
 use Faker\Generator;
 use Marty\McFly\Interface\CreateInterface;
+use ReflectionClass;
+use ReflectionProperty;
+use RuntimeException;
 
 abstract class Fixture extends DoctrineFixture implements CreateInterface
 {
@@ -111,6 +114,30 @@ abstract class Fixture extends DoctrineFixture implements CreateInterface
         }
 
         return $array[array_rand($array)];
+    }
+
+    /**
+     * Create an instance of the entity with Reflection for setting all properties without setter or constructor
+     */
+    public function createFromProperties(string $className, array $properties, array $default = null)
+    {
+
+        // Fusionne avec les valeurs par défaut
+        $properties = array_merge($default, $properties);
+
+        // Créez une instance de la classe ReflectionClass
+        $reflectionClass = new ReflectionClass($className);
+
+        // Utilisez la méthode newInstance() pour créer une instance de la classe
+        $instance = $reflectionClass->newInstance();
+
+        foreach ($properties as $property => $value) {
+            $reflectionProperty = new ReflectionProperty($instance, $property);
+            $reflectionProperty->setAccessible(true); // Rend la propriété accessible
+            $reflectionProperty->setValue($instance, $value); // Définit la valeur de la propriété
+        }
+
+        return $instance;
     }
 
     /**

--- a/src/Fixture.php
+++ b/src/Fixture.php
@@ -25,14 +25,14 @@ abstract class Fixture extends DoctrineFixture implements CreateInterface
         return self::$count;
     }
 
-    protected static function setFaker(Generator $faker): void
-    {
-        self::$faker = $faker;
-    }
-
     protected static function getFaker(): Generator
     {
         return self::$faker;
+    }
+
+    protected static function setFaker(Generator $faker): void
+    {
+        self::$faker = $faker;
     }
 
     /**
@@ -70,23 +70,6 @@ abstract class Fixture extends DoctrineFixture implements CreateInterface
         }
 
         return $object;
-    }
-
-    /**
-     * Create an entity from array (by reflection) with default value, save it and reference it automatically for retrieve
-     */
-    public function createAndSave(
-        string $className,
-        array $properties,
-        array $default = null,
-        array|string $references = null
-    ) {
-
-        $entity = $this->createFromProperties($className, $properties, $default);
-
-        $this->save($entity);
-
-        return $entity;
     }
 
     /**
@@ -131,6 +114,23 @@ abstract class Fixture extends DoctrineFixture implements CreateInterface
         }
 
         return $array[array_rand($array)];
+    }
+
+    /**
+     * Create an entity from array (by reflection) with default value, save it and reference it automatically for retrieve
+     */
+    public function createAndSave(
+        string $className,
+        array $properties,
+        array $default = null,
+        array|string $references = null
+    ): object {
+
+        $entity = $this->createFromProperties($className, $properties, $default);
+
+        $this->save($entity);
+
+        return $entity;
     }
 
     /**

--- a/src/Fixture.php
+++ b/src/Fixture.php
@@ -135,7 +135,7 @@ abstract class Fixture extends DoctrineFixture implements CreateInterface
     /**
      * Create an instance of the entity with Reflection for setting all properties without setter or constructor
      */
-    public function createFromProperties(string $className, array $properties, array $default = null)
+    public function createFromProperties(string $className, array $properties = [], array $default = [])
     {
 
         // Fusionne avec les valeurs par défaut

--- a/src/Fixture.php
+++ b/src/Fixture.php
@@ -3,7 +3,6 @@
 namespace Marty\McFly;
 
 use Doctrine\Bundle\FixturesBundle\Fixture as DoctrineFixture;
-use Exception;
 use Faker\Factory;
 use Faker\Generator;
 use Marty\McFly\Interface\CreateInterface;

--- a/src/Interface/CreateInterface.php
+++ b/src/Interface/CreateInterface.php
@@ -21,7 +21,7 @@ interface CreateInterface
      * @example $this->create('price:100')->setPrice(100) // Créée une entité aléatoire sur l'index 'price:100'
      * @example $this->create(['price:100', 'duration:60'])->setPrice(100)->setDuration(60) // Créée une entité aléatoire sur l'index 'price:100' et 'duration:60'
      */
-    public function create(string|array $references = null): object;
+    public function create(array $properties, string|array $references = null): object;
 
     /**
      * Récupère le nombre d'objet créé pour itéré facilement dessus

--- a/src/Interface/CreateInterface.php
+++ b/src/Interface/CreateInterface.php
@@ -21,7 +21,7 @@ interface CreateInterface
      * @example $this->create('price:100')->setPrice(100) // Créée une entité aléatoire sur l'index 'price:100'
      * @example $this->create(['price:100', 'duration:60'])->setPrice(100)->setDuration(60) // Créée une entité aléatoire sur l'index 'price:100' et 'duration:60'
      */
-    public function create(array $properties, string|array $references = null): object;
+    public function create(?array $properties = null, string|array|null $references = null): object;
 
     /**
      * Récupère le nombre d'objet créé pour itéré facilement dessus

--- a/src/Interface/CreateInterface.php
+++ b/src/Interface/CreateInterface.php
@@ -21,7 +21,7 @@ interface CreateInterface
      * @example $this->create('price:100')->setPrice(100) // Créée une entité aléatoire sur l'index 'price:100'
      * @example $this->create(['price:100', 'duration:60'])->setPrice(100)->setDuration(60) // Créée une entité aléatoire sur l'index 'price:100' et 'duration:60'
      */
-    public function create(?array $properties = null, string|array|null $references = null): object;
+    public function generate(?array $properties = null, string|array|null $references = null): object;
 
     /**
      * Récupère le nombre d'objet créé pour itéré facilement dessus


### PR DESCRIPTION
 - rename create() to generate() for changing method signature without BC
 - generateMany() for generating X entities
 - generate() use Reflection to set properties without setter and contructor
 - use createAndSave() function in generate() for simplify usage